### PR TITLE
Tweak for IDF v4.4.0

### DIFF
--- a/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/src/lgfx/v1/platforms/esp32/common.cpp
@@ -45,7 +45,7 @@ Contributors:
 
 #if defined (ESP_IDF_VERSION_VAL)
  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(3, 4, 0)
-  #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 4)
+  #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 0)
 // include <esp_efuse.h> でエラーが出るバージョンが存在するため、エラー回避用の記述を行ってからincludeする。; 
    #define _ROM_SECURE_BOOT_H_
    #define MAX_KEY_DIGESTS 3


### PR DESCRIPTION
Hello Lovyan03,

Thanks for the fix for ESP-IDF v4.4.4 68ecc55d5c0bec01b012056669068907ff1f6c04 ! I am using IDF version: v4.4-3-g6afb23d90a and the fix is also needed for that version.

I currently get this compile error in v4.4-3-g6afb23d90a:
```bash
Compiling .pio\build\wt-86-32-3zw1_ili9488\lib329\LovyanGFX\lgfx\v1\platforms\esp32\common.cpp.o

In file included from C:/Users/fvanroie/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32s2/include/efuse/include/esp_efuse.h:21,
                 from .pio/libdeps/wt-86-32-3zw1_ili9488/LovyanGFX/src/lgfx/v1/platforms/esp32/common.cpp:59:
C:/Users/fvanroie/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32s2/include/esp_rom/include/esp32s2/rom/secure_boot.h:109:8:
error: redefinition of 'struct ets_secure_boot_key_digests'
 struct ets_secure_boot_key_digests {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/wt-86-32-3zw1_ili9488/LovyanGFX/src/lgfx/v1/platforms/esp32/common.cpp:52:11: note: previous definition of 'struct ets_secure_boot_key_digests'
    struct ets_secure_boot_key_digests
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
*** [.pio\build\wt-86-32-3zw1_ili9488\lib329\LovyanGFX\lgfx\v1\platforms\esp32\common.cpp.o] Error 1
```

I have to change [line 48](https://github.com/fvanroie/LovyanGFX/blob/68ecc55d5c0bec01b012056669068907ff1f6c04/src/lgfx/v1/platforms/esp32/common.cpp#L48) to make it work:
```cpp
  #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 0)
```

It would be nice if this change can make into the next release.

Thank you for your hard work on this library,
fvanroie